### PR TITLE
Fix empty cells throwing error in excel 2003

### DIFF
--- a/lib/exoffice/parser/excel_2003/string.ex
+++ b/lib/exoffice/parser/excel_2003/string.ex
@@ -51,9 +51,13 @@ defmodule Exoffice.Parser.Excel2003.String do
   defp uncompress_byte_string(string) do
     str_len = byte_size(string)
 
-    Enum.reduce(0..(str_len - 1), <<>>, fn i, acc ->
-      acc <> binary_part(string, i, 1) <> "\0"
-    end)
+    if str_len > 0 do
+      Enum.reduce(0..(str_len - 1), <<>>, fn i, acc ->
+        acc <> binary_part(string, i, 1) <> "\0"
+      end)
+    else
+      ""
+    end
   end
 
   def read_byte_string_short(string, codepage) do


### PR DESCRIPTION
There are instances where excel 2003 files throw an error for empty cells. This diff prevents the error from throwing and simply returns an empty string