### PR TITLE
Fix last row missed issue(#22) and infinite loop problem

### DIFF
--- a/lib/exoffice/parser/excel_2003.ex
+++ b/lib/exoffice/parser/excel_2003.ex
@@ -49,7 +49,7 @@ defmodule Exoffice.Parser.Excel2003 do
 
   """
   def count_rows(pid) do
-    Xlsxir.get_multi_info(pid, :rows)
+    :ets.info(pid, :size)
   end
 
   @doc """


### PR DESCRIPTION
Fix issue https://github.com/AlexKovalevych/exoffice/issues/22

it's because of the following codes
https://github.com/jsonkenl/xlsxir/blob/master/lib/xlsxir.ex#L602
```
  defp row_num(tid) do
    # do not count :info key
    :ets.info(tid, :size) - 1
  end
```
and we don't have this :info key when we load xls files

and the infinite loop problem is because of
https://github.com/jsonkenl/xlsxir/blob/master/lib/xlsxir.ex#L510
```
  defp fill_empty_cells(from, to, line, cells) do
    next_ref = next_col(from)

    if next_ref == to do
      fill_empty_cells(to, to, line, [[from, nil] | cells])
    else
      fill_empty_cells(next_ref, to, line, [[from, nil] | cells])
    end
  end
```
the if condition never meets and an infinite loop happens
we can change `next_ref == to` to `next_ref >= to` to enhance robustness
but the root cause is because our cell order of a row in ets differs from the cell order of xlsx format

ets contents of a xlsx file parsed by Xlsxir
```
[
  {1,
   [
     ["A1", "head1"],
     ["B1", "head2"],
     ["C1", "head3"],
     ["D1", "head4"],
     ["E1", "head5"]
   ]},
  {:info, :worksheet_name, "Sheet1"},
  {2, [["A2", "a2"], ["B2", "b2"], ["C2", "c2"], ["D2", "d2"], ["E2", "e2"]]}
]
```

ets contents of a xls file parsed by Exoffice
```
[
  {1,
   [
     ["E1", "head5"],
     ["D1", "head4"],
     ["C1", "head3"],
     ["B1", "head2"],
     ["A1", "head1"]
   ]},
  {2,
   [
     ["E2", "e2"],
     ["D2", "d2"],
     ["C2", "c2"],
     ["B2", "b2"],
     ["A2", "a2"]
   ]}
]
```

